### PR TITLE
Update configs-mover-custom.ps1 -- replace System.IO.File::Exists

### DIFF
--- a/tools/docker-tools/replacer/configs-mover-custom.ps1
+++ b/tools/docker-tools/replacer/configs-mover-custom.ps1
@@ -6,7 +6,7 @@ $project = $args[0]
 [string]$sourceDirectory  = $MyInvocation.MyCommand.Path + "\..\..\..\..\projects\" + $project + "\docker-custom\*"
 [string]$destinationDirectory = $MyInvocation.MyCommand.Path + "\..\..\..\..\projects\" + $project + "\docker-up"
 
-if([System.IO.File]::Exists($sourceDirectory)){
+if(Test-Path $sourceDirectory){
     Copy-item -Force -Recurse -Verbose $sourceDirectory -Destination $destinationDirectory
 } else {
     echo "Custom docker-compose files are not detected ... Skipping this step ..."


### PR DESCRIPTION
08/26/2020
[System.IO.File]::Exists --> changed to Test-Path 
Reason: on Win10/64 it is always false

no custom-configuration / custom dockerfile would be ever used